### PR TITLE
Feature/inherits

### DIFF
--- a/src/Data/SwiftEmmet/Generate.hs
+++ b/src/Data/SwiftEmmet/Generate.hs
@@ -6,10 +6,10 @@ import           Data.SwiftEmmet.Parser
 import qualified Data.Text              as T (Text, intercalate, lines, unlines)
 
 generate :: Expr -> T.Text
-generate (Expr (Struct name) inharits []) = "struct " <> name <> inharitsToText inharits <> " {\n" <> "}"
-generate (Expr (Class  name) inharits []) = "class "  <> name <> inharitsToText inharits <> " {\n" <> initializer [] <> "\n}"
-generate (Expr (Struct name) inharits ps) = "struct " <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n}"
-generate (Expr (Class  name) inharits ps)   "class "  <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n\n" <> initializer ps <> "\n}"
+generate (Expr (Struct name) inherits []) = "struct " <> name <> inheritsToText inherits <> " {\n" <> "}"
+generate (Expr (Class  name) inherits []) = "class "  <> name <> inheritsToText inherits <> " {\n" <> initializer [] <> "\n}"
+generate (Expr (Struct name) inherits ps) = "struct " <> name <> inheritsToText inherits <> " {\n" <> properties ps <> "\n}"
+generate (Expr (Class  name) inherits ps) = "class "  <> name <> inheritsToText inherits <> " {\n" <> properties ps <> "\n\n" <> initializer ps <> "\n}"
 
 properties :: [Property] -> T.Text
 properties = join . map (indent . property)
@@ -38,9 +38,9 @@ indent' xs = join $ map indent $ T.lines xs
 join :: [T.Text] -> T.Text
 join = T.intercalate "\n"
 
-inharitsToText :: [Inharit] -> T.Text 
-inharitsToText [] = ""
-inharitsToText xs = ": " <> (T.intercalate ", " $ map toText xs)
+inheritsToText :: [Inherit] -> T.Text 
+inheritsToText [] = ""
+inheritsToText xs = ": " <> (T.intercalate ", " $ map toText xs)
     where
-        toText :: Inharit -> T.Text
-        toText (Inharit x) = x
+        toText :: Inherit -> T.Text
+        toText (Inherit x) = x

--- a/src/Data/SwiftEmmet/Generate.hs
+++ b/src/Data/SwiftEmmet/Generate.hs
@@ -3,7 +3,7 @@
 module Data.SwiftEmmet.Generate (generate) where
 
 import           Data.SwiftEmmet.Parser
-import qualified Data.Text              as T (Text, intercalate, lines, unlines, concat, append)
+import qualified Data.Text              as T (Text, intercalate, lines, unlines)
 
 generate :: Expr -> T.Text
 generate (Expr (Struct name) inharits []) = "struct " <> name <> inharitsToText inharits <> " {\n" <> "}"

--- a/src/Data/SwiftEmmet/Generate.hs
+++ b/src/Data/SwiftEmmet/Generate.hs
@@ -40,7 +40,4 @@ join = T.intercalate "\n"
 
 inheritsToText :: [Inherit] -> T.Text 
 inheritsToText [] = ""
-inheritsToText xs = ": " <> (T.intercalate ", " $ map toText xs)
-    where
-        toText :: Inherit -> T.Text
-        toText (Inherit x) = x
+inheritsToText xs = ": " <> T.intercalate ", " (map unInherit xs)

--- a/src/Data/SwiftEmmet/Generate.hs
+++ b/src/Data/SwiftEmmet/Generate.hs
@@ -3,13 +3,13 @@
 module Data.SwiftEmmet.Generate (generate) where
 
 import           Data.SwiftEmmet.Parser
-import qualified Data.Text              as T (Text, intercalate, lines, unlines)
+import qualified Data.Text              as T (Text, intercalate, lines, unlines, concat, append)
 
 generate :: Expr -> T.Text
-generate (Expr (Struct name) []) = "struct " <> name <> " {\n" <> "}"
-generate (Expr (Class name)  []) = "class "  <> name <> " {\n" <> initializer [] <> "\n}"
-generate (Expr (Struct name) ps) = "struct " <> name <> " {\n" <> properties ps <> "\n}"
-generate (Expr (Class name) ps)  = "class "  <> name <> " {\n" <> properties ps <> "\n\n" <> initializer ps <> "\n}"
+generate (Expr (Struct name) inharits []) = "struct " <> name <> inharitsToText inharits <> " {\n" <> "}"
+generate (Expr (Class name) inharits []) = "class "  <> name <> inharitsToText inharits <> " {\n" <> initializer [] <> "\n}"
+generate (Expr (Struct name) inharits ps) = "struct " <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n}"
+generate (Expr (Class name) inharits ps)  = "class "  <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n\n" <> initializer ps <> "\n}"
 
 properties :: [Property] -> T.Text
 properties = join . map (indent . property)
@@ -37,3 +37,10 @@ indent' xs = join $ map indent $ T.lines xs
 
 join :: [T.Text] -> T.Text
 join = T.intercalate "\n"
+
+inharitsToText :: [Inharit] -> T.Text 
+inharitsToText [] = ""
+inharitsToText xs = ": " <> (T.intercalate ", " $ map toText xs)
+    where
+        toText :: Inharit -> T.Text
+        toText (Inharit x) = x

--- a/src/Data/SwiftEmmet/Generate.hs
+++ b/src/Data/SwiftEmmet/Generate.hs
@@ -7,9 +7,9 @@ import qualified Data.Text              as T (Text, intercalate, lines, unlines)
 
 generate :: Expr -> T.Text
 generate (Expr (Struct name) inharits []) = "struct " <> name <> inharitsToText inharits <> " {\n" <> "}"
-generate (Expr (Class name) inharits []) = "class "  <> name <> inharitsToText inharits <> " {\n" <> initializer [] <> "\n}"
+generate (Expr (Class  name) inharits []) = "class "  <> name <> inharitsToText inharits <> " {\n" <> initializer [] <> "\n}"
 generate (Expr (Struct name) inharits ps) = "struct " <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n}"
-generate (Expr (Class name) inharits ps)  = "class "  <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n\n" <> initializer ps <> "\n}"
+generate (Expr (Class  name) inharits ps)   "class "  <> name <> inharitsToText inharits <> " {\n" <> properties ps <> "\n\n" <> initializer ps <> "\n}"
 
 properties :: [Property] -> T.Text
 properties = join . map (indent . property)

--- a/src/Data/SwiftEmmet/Parser.hs
+++ b/src/Data/SwiftEmmet/Parser.hs
@@ -8,7 +8,7 @@ module Data.SwiftEmmet.Parser
     , Property (Property)
     , DataType (Struct, Class)
     , Expr (Expr)
-    , Inharit (Inharit)
+    , Inherit (Inherit)
     ) where
 
 import           Control.Applicative
@@ -23,9 +23,9 @@ data Property = Property VariableType Field Type deriving (Show, Eq)
 data DataType = Struct Text
               | Class Text
               deriving (Show, Eq)
-data Inharit = Inharit Text deriving (Show, Eq)
+data Inherit = Inherit Text deriving (Show, Eq)
 
-data Expr = Expr DataType [Inharit] [Property] deriving (Show, Eq)
+data Expr = Expr DataType [Inherit] [Property] deriving (Show, Eq)
 
 parseExpr :: Text -> Either Text Expr
 parseExpr s = showParseResult
@@ -34,7 +34,7 @@ parseExpr s = showParseResult
 exprParser :: Parser Expr
 exprParser = Expr
     <$> dataTypeParser
-    <*> inharitsParser
+    <*> inheritsParser
     <*> ((schar '=' *> propertiesParser <* endOfInput) <|> (endOfInput >> pure []))
 
 dataTypeParser :: Parser DataType
@@ -73,12 +73,12 @@ resolveAlias t = case toUpper t of
     "U" -> "URL"
     _   -> t
 
-inharitsParser :: Parser [Inharit]
-inharitsParser = schar ':' *> inharitParser `sepBy` schar ',' 
+inheritsParser :: Parser [Inherit]
+inheritsParser = schar ':' *> inheritParser `sepBy` schar ',' 
               <|> return []
     where 
-        inharitParser :: Parser Inharit
-        inharitParser = Inharit <$> word
+        inheritParser :: Parser Inherit
+        inheritParser = Inherit <$> word
 
 -- ignore case-sensitive
 ichar :: Char -> Parser Char

--- a/src/Data/SwiftEmmet/Parser.hs
+++ b/src/Data/SwiftEmmet/Parser.hs
@@ -8,7 +8,7 @@ module Data.SwiftEmmet.Parser
     , Property (Property)
     , DataType (Struct, Class)
     , Expr (Expr)
-    , Inherit (Inherit)
+    , Inherit (Inherit, unInherit)
     ) where
 
 import           Control.Applicative
@@ -23,7 +23,7 @@ data Property = Property VariableType Field Type deriving (Show, Eq)
 data DataType = Struct Text
               | Class Text
               deriving (Show, Eq)
-data Inherit = Inherit Text deriving (Show, Eq)
+newtype Inherit = Inherit { unInherit :: Text } deriving (Show, Eq)
 
 data Expr = Expr DataType [Inherit] [Property] deriving (Show, Eq)
 

--- a/src/Data/SwiftEmmet/Parser.hs
+++ b/src/Data/SwiftEmmet/Parser.hs
@@ -8,6 +8,7 @@ module Data.SwiftEmmet.Parser
     , Property (Property)
     , DataType (Struct, Class)
     , Expr (Expr)
+    , Inharit (Inharit)
     ) where
 
 import           Control.Applicative
@@ -22,7 +23,9 @@ data Property = Property VariableType Field Type deriving (Show, Eq)
 data DataType = Struct Text
               | Class Text
               deriving (Show, Eq)
-data Expr = Expr DataType [Property] deriving (Show, Eq)
+data Inharit = Inharit Text deriving (Show, Eq)
+
+data Expr = Expr DataType [Inharit] [Property] deriving (Show, Eq)
 
 parseExpr :: Text -> Either Text Expr
 parseExpr s = showParseResult
@@ -31,6 +34,7 @@ parseExpr s = showParseResult
 exprParser :: Parser Expr
 exprParser = Expr
     <$> dataTypeParser
+    <*> inharitsParser
     <*> ((schar '=' *> propertiesParser <* endOfInput) <|> (endOfInput >> pure []))
 
 dataTypeParser :: Parser DataType
@@ -68,6 +72,13 @@ resolveAlias t = case toUpper t of
     "D" -> "Double"
     "U" -> "URL"
     _   -> t
+
+inharitsParser :: Parser [Inharit]
+inharitsParser = schar ':' *> inharitParser `sepBy` schar ',' 
+              <|> return []
+    where 
+        inharitParser :: Parser Inharit
+        inharitParser = Inharit <$> word
 
 -- ignore case-sensitive
 ichar :: Char -> Parser Char

--- a/test/GenerateSpec.hs
+++ b/test/GenerateSpec.hs
@@ -53,23 +53,23 @@ generateTest = TestList
                  , "}" ]
     ]
 
-generateWithInharitsTest :: Test
-generateWithInharitsTest = TestList
-    [ "generate inharits test 1" ~:
-        generate (Expr (Struct "Person") [Inharit "Foo"] [])
+generateWithInheritsTest :: Test
+generateWithInheritsTest = TestList
+    [ "generate inherits test 1" ~:
+        generate (Expr (Struct "Person") [Inherit "Foo"] [])
         ~?= text [ "struct Person: Foo {"
                  , "}"]
-    , "generate inharits test 2" ~:
-        generate (Expr (Struct "Person") [Inharit "Foo", Inharit "Bar"] [])
+    , "generate inherits test 2" ~:
+        generate (Expr (Struct "Person") [Inherit "Foo", Inherit "Bar"] [])
         ~?= text [ "struct Person: Foo, Bar {"
                  , "}"]
-    , "generate inharits test 3" ~:
-        generate (Expr (Class "Person") [Inharit "Foo"] [])
+    , "generate inherits test 3" ~:
+        generate (Expr (Class "Person") [Inherit "Foo"] [])
         ~?= text [ "class Person: Foo {"
                  , "    init() {}"
                  , "}"]
-    , "generate inharits test 4" ~:
-        generate (Expr (Class "Person") [Inharit "Foo", Inharit "Bar"] [])
+    , "generate inherits test 4" ~:
+        generate (Expr (Class "Person") [Inherit "Foo", Inherit "Bar"] [])
         ~?= text [ "class Person: Foo, Bar {"
                  , "    init() {}"
                  , "}"]

--- a/test/GenerateSpec.hs
+++ b/test/GenerateSpec.hs
@@ -10,21 +10,21 @@ import Data.Text
 generateTest :: Test 
 generateTest = TestList
     [ "generate test 1" ~:
-        generate (Expr (Struct "Person") [])
+        generate (Expr (Struct "Person") [] [])
         ~?= text [ "struct Person {"
                  , "}" ]
     , "generate test 2" ~:
-        generate (Expr (Class "Person") [])
+        generate (Expr (Class "Person") [] [])
         ~?= text [ "class Person {"
                  , "    init() {}"
                  , "}" ]
     , "generate test 3" ~:
-        generate (Expr (Struct "Person") [Property Let "name" "String"])
+        generate (Expr (Struct "Person") [] [Property Let "name" "String"])
         ~?= text [ "struct Person {"
                  , "    let name: String"
                  , "}" ]
     , "generate test 4" ~:
-        generate (Expr (Struct "Person") [ Property Let "name"   "String"
+        generate (Expr (Struct "Person") [] [ Property Let "name"   "String"
                                          , Property Var "age"    "Int"
                                          , Property Var "weight" "Double"
                                          ])
@@ -34,7 +34,7 @@ generateTest = TestList
                  , "    var weight: Double"
                  , "}" ]
     , "generate test 5" ~:
-        generate (Expr (Class "Person") [ Property Let "name"   "String"
+        generate (Expr (Class "Person") [] [ Property Let "name"   "String"
                                         , Property Var "age"    "Int"
                                         , Property Var "weight" "Double"
                                         ])
@@ -51,6 +51,28 @@ generateTest = TestList
                  , "        self.weight = weight"
                  , "    }"
                  , "}" ]
+    ]
+
+generateWithInharitsTest :: Test
+generateWithInharitsTest = TestList
+    [ "generate inharits test 1" ~:
+        generate (Expr (Struct "Person") [Inharit "Foo"] [])
+        ~?= text [ "struct Person: Foo {"
+                 , "}"]
+    , "generate inharits test 2" ~:
+        generate (Expr (Struct "Person") [Inharit "Foo", Inharit "Bar"] [])
+        ~?= text [ "struct Person: Foo, Bar {"
+                 , "}"]
+    , "generate inharits test 3" ~:
+        generate (Expr (Class "Person") [Inharit "Foo"] [])
+        ~?= text [ "class Person: Foo {"
+                 , "    init() {}"
+                 , "}"]
+    , "generate inharits test 4" ~:
+        generate (Expr (Class "Person") [Inharit "Foo", Inharit "Bar"] [])
+        ~?= text [ "class Person: Foo, Bar {"
+                 , "    init() {}"
+                 , "}"]
     ]
 
 text :: [Text] -> Text

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -9,33 +9,33 @@ parseExprTest :: Test
 parseExprTest = TestList
     [ "parse test 0" ~:
         parseExpr "S.Person"
-        ~?= Right (Expr (Struct "Person") [])
+        ~?= Right (Expr (Struct "Person") [] [])
     , "parse test 1" ~:
         parseExpr "C.Person=l.name:String"
-        ~?= Right (Expr (Class "Person") [Property Let "name" "String"])
+        ~?= Right (Expr (Class "Person") [] [Property Let "name" "String"])
     , "parse test 2" ~:
         parseExpr "S.Person=l.name:String,v.age:Int,v.weight:Double"
-        ~?= Right (Expr (Struct "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Let "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     , "parse test 3" ~:
         parseExpr "S.Person=l.name:S,v.age:I,v.weight:D"
-        ~?= Right (Expr (Struct "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Let "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     , "parse test 4" ~:
         parseExpr "s.Person=l.name:s,v.age:i,v.weight:d"
-        ~?= Right (Expr (Struct "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Let "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     , "parse test 5" ~:
         parseExpr "c.Person=l.name:s,v.age:i,v.weight:d"
-        ~?= Right (Expr (Class "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Class "Person") [] [ Property Let "name" "String"
                                          , Property Var "age" "Int"
                                          , Property Var "weight" "Double"])
     , "parse test 6" ~:
         parseExpr "S.Person=name:String,age:Int,weight:Double"
-        ~?= Right (Expr (Struct "Person") [ Property Var "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Var "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     ]
@@ -44,35 +44,57 @@ parseExprWithSpaceTest :: Test
 parseExprWithSpaceTest = TestList
     [ "parse white-space test 0" ~:
         parseExpr "S . Person"
-        ~?= Right (Expr (Struct "Person") [])
+        ~?= Right (Expr (Struct "Person") [] [])
     , "parse white-space test 1" ~:
         parseExpr "C . Person = l . name : String"
-        ~?= Right (Expr (Class "Person") [Property Let "name" "String"])
+        ~?= Right (Expr (Class "Person") [] [Property Let "name" "String"])
     , "parse white-space test 2" ~:
         parseExpr "S . Person = l . name : String , v . age : Int , v . weight : Double"
-        ~?= Right (Expr (Struct "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Let "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     , "parse white-space test 3" ~:
         parseExpr "S . Person = l . name : S , v . age : I , v . weight : D"
-        ~?= Right (Expr (Struct "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Let "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     , "parse white-space test 4" ~:
         parseExpr "s . Person = l . name : s , v . age : i , v . weight : d"
-        ~?= Right (Expr (Struct "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Let "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
     , "parse white-space test 5" ~:
         parseExpr "c . Person = l . name : s , v . age : i , v . weight : d"
-        ~?= Right (Expr (Class "Person") [ Property Let "name" "String"
+        ~?= Right (Expr (Class "Person") [] [ Property Let "name" "String"
                                          , Property Var "age" "Int"
                                          , Property Var "weight" "Double"])
     , "parse white-space test 6" ~:
         parseExpr "S . Person = name : String , age : Int , weight : Double"
-        ~?= Right (Expr (Struct "Person") [ Property Var "name" "String"
+        ~?= Right (Expr (Struct "Person") [] [ Property Var "name" "String"
                                           , Property Var "age" "Int"
                                           , Property Var "weight" "Double"])
+    ]
+
+parseExprWithInharitsTest :: Test
+parseExprWithInharitsTest = TestList
+    [ "parse inharits test 1" ~:
+        parseExpr "S.Person: Foo"
+            ~?= Right (Expr (Struct "Person") [Inharit "Foo"] [])
+    , "parse inharits test 2" ~:
+        parseExpr "S.Parson: Foo = l.name: s"
+            ~?= Right (Expr (Struct "Parson") [Inharit "Foo"] [Property Let "name" "String"])
+    , "parse inharits test 3" ~:
+        parseExpr "S.Person: Foo, Bar"
+            ~?= Right (Expr (Struct "Person") [Inharit "Foo", Inharit "Bar"] [])
+    , "parse inharits test 4" ~:
+        parseExpr "C.Person: Foo"
+            ~?= Right (Expr (Class "Person") [Inharit "Foo"] [])
+    , "parse inharits test 5" ~:
+        parseExpr "C.Parson: Foo = l.name: s"
+            ~?= Right (Expr (Class "Parson") [Inharit "Foo"] [Property Let "name" "String"])
+    , "parse inharits test 6" ~:
+        parseExpr "C.Person: Foo, Bar"
+            ~?= Right (Expr (Class "Person") [Inharit "Foo", Inharit "Bar"] [])
     ]
 
 parseExprAliasTest :: Test
@@ -80,6 +102,7 @@ parseExprAliasTest = TestList
     [ "parseExpr alias test 1" ~:
       parseExpr "S.Foo = v.s:S, v.b:B, v.i:I, v.l:L, v.f:F, v.d:D, v.u:U, v.other:Other"
       ~?= Right (Expr (Struct "Foo")
+        []
         [ Property Var "s" "String"
         , Property Var "b" "Bool"
         , Property Var "i" "Int"

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -75,26 +75,26 @@ parseExprWithSpaceTest = TestList
                                           , Property Var "weight" "Double"])
     ]
 
-parseExprWithInharitsTest :: Test
-parseExprWithInharitsTest = TestList
-    [ "parse inharits test 1" ~:
+parseExprWithInheritsTest :: Test
+parseExprWithInheritsTest = TestList
+    [ "parse inherits test 1" ~:
         parseExpr "S.Person: Foo"
-            ~?= Right (Expr (Struct "Person") [Inharit "Foo"] [])
-    , "parse inharits test 2" ~:
+            ~?= Right (Expr (Struct "Person") [Inherit "Foo"] [])
+    , "parse inherits test 2" ~:
         parseExpr "S.Parson: Foo = l.name: s"
-            ~?= Right (Expr (Struct "Parson") [Inharit "Foo"] [Property Let "name" "String"])
-    , "parse inharits test 3" ~:
+            ~?= Right (Expr (Struct "Parson") [Inherit "Foo"] [Property Let "name" "String"])
+    , "parse inherits test 3" ~:
         parseExpr "S.Person: Foo, Bar"
-            ~?= Right (Expr (Struct "Person") [Inharit "Foo", Inharit "Bar"] [])
-    , "parse inharits test 4" ~:
+            ~?= Right (Expr (Struct "Person") [Inherit "Foo", Inherit "Bar"] [])
+    , "parse inherits test 4" ~:
         parseExpr "C.Person: Foo"
-            ~?= Right (Expr (Class "Person") [Inharit "Foo"] [])
-    , "parse inharits test 5" ~:
+            ~?= Right (Expr (Class "Person") [Inherit "Foo"] [])
+    , "parse inherits test 5" ~:
         parseExpr "C.Parson: Foo = l.name: s"
-            ~?= Right (Expr (Class "Parson") [Inharit "Foo"] [Property Let "name" "String"])
-    , "parse inharits test 6" ~:
+            ~?= Right (Expr (Class "Parson") [Inherit "Foo"] [Property Let "name" "String"])
+    , "parse inherits test 6" ~:
         parseExpr "C.Person: Foo, Bar"
-            ~?= Right (Expr (Class "Person") [Inharit "Foo", Inharit "Bar"] [])
+            ~?= Right (Expr (Class "Person") [Inherit "Foo", Inherit "Bar"] [])
     ]
 
 parseExprAliasTest :: Test

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,5 +11,7 @@ main = do
         , parseExprWithSpaceTest
         , parseExprAliasTest
         , generateTest
+        , parseExprWithInharitsTest
+        , generateWithInharitsTest
         ]
     return ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,7 +11,7 @@ main = do
         , parseExprWithSpaceTest
         , parseExprAliasTest
         , generateTest
-        , parseExprWithInharitsTest
-        , generateWithInharitsTest
+        , parseExprWithInheritsTest
+        , generateWithInheritsTest
         ]
     return ()


### PR DESCRIPTION
型定義の際に継承を指定できるようにしました。
`swift-emmet 's.Person: Foo = l.name: String'`
↓
```
struct Person: Foo {
    let name: String
}
```
OSSへのPRは初めてなので指摘等ありましたらお伝えいただけると助かります。